### PR TITLE
Enable slack logging when log level is `error` or higher

### DIFF
--- a/backend/config/logging.php
+++ b/backend/config/logging.php
@@ -36,7 +36,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['daily'],
+            'channels' => ['daily', 'slack'],
             'ignore_exceptions' => false,
         ],
 
@@ -58,7 +58,7 @@ return [
             'url' => env('LOG_SLACK_WEBHOOK_URL'),
             'username' => 'Laravel Log',
             'emoji' => ':boom:',
-            'level' => env('LOG_LEVEL', 'critical'),
+            'level' => 'error',
         ],
 
         'papertrail' => [


### PR DESCRIPTION
- This is the setting that was missing in #16 