### PR TITLE
Enable dependency injection for API resources

### DIFF
--- a/backend/app/Http/Controllers/Auth/ProfileInformationController.php
+++ b/backend/app/Http/Controllers/Auth/ProfileInformationController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Resources\UserResource;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
 use Laravel\Fortify\Http\Controllers\ProfileInformationController as Controller;
 
 /**
@@ -12,12 +12,23 @@ use Laravel\Fortify\Http\Controllers\ProfileInformationController as Controller;
 class ProfileInformationController extends Controller
 {
     /**
+     * @param \App\Http\Resources\UserResource $userResource
+     */
+    public function __construct(private UserResource $userResource)
+    {
+        //
+    }
+
+    /**
      * Display the authenticated user
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function show()
+    public function show(Request $request)
     {
-        return new UserResource(Auth::user());
+        /** @var ?\App\Models\User The authenticated user if logged in */
+        $user = $request->user();
+
+        return $this->userResource->make($user);
     }
 }

--- a/backend/app/Http/Controllers/HomeController.php
+++ b/backend/app/Http/Controllers/HomeController.php
@@ -3,19 +3,34 @@
 namespace App\Http\Controllers;
 
 use App\Http\Resources\UserResource;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class HomeController extends Controller
 {
     /**
+     * @param \App\Http\Resources\UserResource $userResource
+     * @see https://laravel.com/docs/controllers#dependency-injection-and-controllers
+     * @see https://laravel.com/docs/container
+     */
+    public function __construct(private UserResource $userResource)
+    {
+        //
+    }
+
+    /**
      * Return the authenticated user or a welcome message
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Resources\Json\JsonResource|\Illuminate\Http\JsonResponse
      */
-    public function index()
+    public function index(Request $request): JsonResource|JsonResponse
     {
-        return Auth::check()
-            ? new UserResource(Auth::user())
+        /** @var ?\App\Models\User The authenticated user if logged in */
+        $user = $request->user();
+
+        return $user
+            ? $this->userResource->make($user)
             : response()->json([
                 'message' => 'Welcome to ' . config('app.name'),
             ]);

--- a/backend/app/Http/Controllers/V1/TaskBoardController.php
+++ b/backend/app/Http/Controllers/V1/TaskBoardController.php
@@ -12,10 +12,11 @@ use App\Models\User;
 class TaskBoardController extends Controller
 {
     /**
+     * @param \App\Http\Resources\TaskBoardResource $taskBoardResource
      * @see https://laravel.com/docs/controllers#dependency-injection-and-controllers
      * @see https://laravel.com/docs/container
      */
-    public function __construct()
+    public function __construct(private TaskBoardResource $taskBoardResource)
     {
         // > This method will attach the appropriate can middleware definitions
         // > to the resource controller's methods.
@@ -37,7 +38,7 @@ class TaskBoardController extends Controller
      */
     public function index(User $user)
     {
-        return TaskBoardResource::collection(
+        return $this->taskBoardResource->collection(
             $user
                 ->taskBoards()
                 ->getQuery()
@@ -76,7 +77,7 @@ class TaskBoardController extends Controller
          */
         $created = $user->taskBoards()->create($validated);
 
-        return TaskBoardResource::make($created);
+        return $this->taskBoardResource->make($created);
     }
 
     /**
@@ -92,7 +93,7 @@ class TaskBoardController extends Controller
      */
     public function show(User $user, TaskBoard $taskBoard)
     {
-        return TaskBoardResource::make(
+        return $this->taskBoardResource->make(
             $taskBoard->load([
                 // > When using this feature, you should always include
                 // > the id column and any relevant foreign key columns
@@ -120,7 +121,7 @@ class TaskBoardController extends Controller
     ) {
         $taskBoard->update($request->validated());
 
-        return TaskBoardResource::make($taskBoard);
+        return $this->taskBoardResource->make($taskBoard);
     }
 
     /**
@@ -134,6 +135,6 @@ class TaskBoardController extends Controller
     {
         $taskBoard->delete();
 
-        return TaskBoardResource::make($taskBoard);
+        return $this->taskBoardResource->make($taskBoard);
     }
 }

--- a/backend/app/Http/Controllers/V1/TaskCardController.php
+++ b/backend/app/Http/Controllers/V1/TaskCardController.php
@@ -13,10 +13,11 @@ use Illuminate\Support\Facades\Auth;
 class TaskCardController extends Controller
 {
     /**
+     * @param \App\Http\Resources\TaskCardResource $taskCardResource
      * @see https://laravel.com/docs/controllers#dependency-injection-and-controllers
      * @see https://laravel.com/docs/container
      */
-    public function __construct()
+    public function __construct(private TaskCardResource $taskCardResource)
     {
         // > This method will attach the appropriate can middleware definitions
         // > to the resource controller's methods.
@@ -54,7 +55,7 @@ class TaskCardController extends Controller
         $created->user()->associate(Auth::id());
         $created->save();
 
-        return TaskCardResource::make($created);
+        return $this->taskCardResource->make($created);
     }
 
     /**
@@ -78,7 +79,7 @@ class TaskCardController extends Controller
 
         $taskCard->update($validated);
 
-        return TaskCardResource::make($taskCard);
+        return $this->taskCardResource->make($taskCard);
     }
 
     /**
@@ -92,6 +93,6 @@ class TaskCardController extends Controller
     {
         $taskCard->delete();
 
-        return TaskCardResource::make($taskCard);
+        return $this->taskCardResource->make($taskCard);
     }
 }

--- a/backend/app/Http/Controllers/V1/TaskListController.php
+++ b/backend/app/Http/Controllers/V1/TaskListController.php
@@ -13,10 +13,11 @@ use Illuminate\Support\Facades\Auth;
 class TaskListController extends Controller
 {
     /**
+     * @param \App\Http\Resources\TaskListResource $taskListResource
      * @see https://laravel.com/docs/controllers#dependency-injection-and-controllers
      * @see https://laravel.com/docs/container
      */
-    public function __construct()
+    public function __construct(private TaskListResource $taskListResource)
     {
         // > This method will attach the appropriate can middleware definitions
         // > to the resource controller's methods.
@@ -51,7 +52,7 @@ class TaskListController extends Controller
         $created->user()->associate(Auth::id());
         $created->save();
 
-        return TaskListResource::make($created);
+        return $this->taskListResource->make($created);
     }
 
     /**
@@ -69,7 +70,7 @@ class TaskListController extends Controller
     ) {
         $taskList->update($request->validated());
 
-        return TaskListResource::make($taskList);
+        return $this->taskListResource->make($taskList);
     }
 
     /**
@@ -83,6 +84,6 @@ class TaskListController extends Controller
     {
         $taskList->delete();
 
-        return TaskListResource::make($taskList);
+        return $this->taskListResource->make($taskList);
     }
 }

--- a/backend/app/Http/Resources/ApiResource.php
+++ b/backend/app/Http/Resources/ApiResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\MissingValue;
+
+/**
+ * It's used to transform the model and define what data should be returned.
+ *
+ * @see \App\Providers\ApiResourceServiceProvider
+ * @see https://laravel.com/docs/eloquent-resources
+ */
+abstract class ApiResource extends JsonResource
+{
+    /**
+     * The resource instance when loaded.
+     *
+     * @var \Illuminate\Http\Resources\MissingValue
+     * @see \Illuminate\Http\Resources\ConditionallyLoadsAttributes ::removeMissingValues
+     * @see https://laravel.com/docs/eloquent-resources#conditional-relationships
+     */
+    public $resource;
+
+    /**
+     * Create a new resource instance.
+     *
+     * @param  \Illuminate\Http\Resources\MissingValue  $resource
+     * @return void
+     */
+    public function __construct(MissingValue $resource)
+    {
+        $this->resource = $resource;
+    }
+}

--- a/backend/app/Http/Resources/TaskBoardResource.php
+++ b/backend/app/Http/Resources/TaskBoardResource.php
@@ -3,22 +3,16 @@
 namespace App\Http\Resources;
 
 use App\Models\TaskBoard;
-use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\MissingValue;
 
-/**
- * It's used to transform the model and define what data should be returned.
- *
- * @see https://laravel.com/docs/eloquent-resources
- */
-class TaskBoardResource extends JsonResource
+class TaskBoardResource extends ApiResource
 {
     /**
      * `TaskBoard` resource instance when loaded.
      *
      * @var \App\Models\TaskBoard|\Illuminate\Http\Resources\MissingValue
      */
-    public $resource; // Type declaration can't be used
+    public $resource;
 
     /**
      * Create a new resource instance.

--- a/backend/app/Http/Resources/TaskBoardResource.php
+++ b/backend/app/Http/Resources/TaskBoardResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use App\Models\TaskBoard;
 use Illuminate\Http\Resources\MissingValue;
+use Illuminate\Support\Facades\App;
 
 class TaskBoardResource extends ApiResource
 {
@@ -37,13 +38,15 @@ class TaskBoardResource extends ApiResource
         // But it's not type-safe. So access via a typed variable.
         // e.g. `$this->resource->id` instead of `this->id`
         $taskBoard = $this->resource;
+        /** @var \App\Http\Resources\TaskListResource $taskListResource */
+        $taskListResource = App::make(TaskListResource::class);
 
         return [
             'id' => $taskBoard->id,
             'userId' => $taskBoard->user_id,
             'title' => $taskBoard->title,
             'description' => $taskBoard->description,
-            'lists' => TaskListResource::collection(
+            'lists' => $taskListResource->collection(
                 $this->whenLoaded('taskLists'),
             ),
             'createdAt' => $taskBoard->created_at,

--- a/backend/app/Http/Resources/TaskCardResource.php
+++ b/backend/app/Http/Resources/TaskCardResource.php
@@ -3,22 +3,16 @@
 namespace App\Http\Resources;
 
 use App\Models\TaskCard;
-use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\MissingValue;
 
-/**
- * It's used to transform the model and define what data should be returned.
- *
- * @see https://laravel.com/docs/eloquent-resources
- */
-class TaskCardResource extends JsonResource
+class TaskCardResource extends ApiResource
 {
     /**
      * `TaskCard` resource instance when loaded.
      *
      * @var \App\Models\TaskCard|\Illuminate\Http\Resources\MissingValue
      */
-    public $resource; // Type declaration can't be used
+    public $resource;
 
     /**
      * Create a new resource instance.

--- a/backend/app/Http/Resources/TaskListResource.php
+++ b/backend/app/Http/Resources/TaskListResource.php
@@ -3,24 +3,16 @@
 namespace App\Http\Resources;
 
 use App\Models\TaskList;
-use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\MissingValue;
 
-/**
- * It's used to transform the model and define what data should be returned.
- *
- * @see https://laravel.com/docs/eloquent-resources
- */
-class TaskListResource extends JsonResource
+class TaskListResource extends ApiResource
 {
     /**
      * `TaskList` resource instance when loaded.
      *
      * @var \App\Models\TaskList|\Illuminate\Http\Resources\MissingValue
-     * @see \Illuminate\Http\Resources\ConditionallyLoadsAttributes ::removeMissingValues
-     * @see https://laravel.com/docs/eloquent-resources#conditional-relationships
      */
-    public $resource; // Type declaration can't be used
+    public $resource;
 
     /**
      * Create a new resource instance.

--- a/backend/app/Http/Resources/TaskListResource.php
+++ b/backend/app/Http/Resources/TaskListResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use App\Models\TaskList;
 use Illuminate\Http\Resources\MissingValue;
+use Illuminate\Support\Facades\App;
 
 class TaskListResource extends ApiResource
 {
@@ -37,12 +38,14 @@ class TaskListResource extends ApiResource
         // But it's not type-safe. So access via a typed variable.
         // e.g. `$this->resource->id` instead of `this->id`
         $taskList = $this->resource;
+        /** @var \App\Http\Resources\TaskCardResource $taskCardResource */
+        $taskCardResource = App::make(TaskCardResource::class);
 
         return [
             'id' => $taskList->id,
             'userId' => $taskList->user_id,
             'boardId' => $taskList->task_board_id,
-            'cards' => TaskCardResource::collection(
+            'cards' => $taskCardResource->collection(
                 $this->whenLoaded('taskCards'),
             ),
             'title' => $taskList->title,

--- a/backend/app/Http/Resources/UserResource.php
+++ b/backend/app/Http/Resources/UserResource.php
@@ -3,22 +3,14 @@
 namespace App\Http\Resources;
 
 use App\Models\User;
-use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\MissingValue;
 
-/**
- * It's used to transform the model and define what data should be returned.
- *
- * @see https://laravel.com/docs/eloquent-resources
- */
-class UserResource extends JsonResource
+class UserResource extends ApiResource
 {
     /**
      * `User` resource instance when loaded.
      *
      * @var \App\Models\User|\Illuminate\Http\Resources\MissingValue
-     * @see \Illuminate\Http\Resources\ConditionallyLoadsAttributes ::removeMissingValues
-     * @see https://laravel.com/docs/eloquent-resources#conditional-relationships
      */
     public $resource;
 

--- a/backend/app/Http/Responses/LoginResponse.php
+++ b/backend/app/Http/Responses/LoginResponse.php
@@ -3,11 +3,18 @@
 namespace App\Http\Responses;
 
 use App\Http\Resources\UserResource;
-use Illuminate\Support\Facades\Auth;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 
 class LoginResponse implements LoginResponseContract
 {
+    /**
+     * @param \App\Http\Resources\UserResource $userResource
+     */
+    public function __construct(private UserResource $userResource)
+    {
+        //
+    }
+
     /**
      * Create an HTTP response that represents the object.
      *
@@ -19,7 +26,7 @@ class LoginResponse implements LoginResponseContract
     {
         return $request->wantsJson()
             ? response()->json([
-                'user' => new UserResource(Auth::user()),
+                'user' => $this->userResource->make($request->user()),
                 'two_factor' => false,
             ])
             : redirect()->intended(config('fortify.home'));

--- a/backend/app/Http/Responses/RegisterResponse.php
+++ b/backend/app/Http/Responses/RegisterResponse.php
@@ -3,12 +3,18 @@
 namespace App\Http\Responses;
 
 use App\Http\Resources\UserResource;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 
 class RegisterResponse implements RegisterResponseContract
 {
+    /**
+     * @param \App\Http\Resources\UserResource $userResource
+     */
+    public function __construct(private UserResource $userResource)
+    {
+        //
+    }
+
     /**
      * Create an HTTP response that represents the object.
      *
@@ -18,9 +24,11 @@ class RegisterResponse implements RegisterResponseContract
      */
     public function toResponse($request)
     {
-        // `201`の他、Userを返却
         return $request->wantsJson()
-            ? new JsonResponse(['user' => new UserResource(Auth::user())], 201)
+            ? response()->json(
+                ['user' => $this->userResource->make($request->user())],
+                201,
+            )
             : redirect()->intended(config('fortify.home'));
     }
 }

--- a/backend/app/Http/Responses/VerifyEmailResponse.php
+++ b/backend/app/Http/Responses/VerifyEmailResponse.php
@@ -3,12 +3,18 @@
 namespace App\Http\Responses;
 
 use App\Http\Resources\UserResource;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
 use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
 
 class VerifyEmailResponse implements VerifyEmailResponseContract
 {
+    /**
+     * @param \App\Http\Resources\UserResource $userResource
+     */
+    public function __construct(private UserResource $userResource)
+    {
+        //
+    }
+
     /**
      * Create an HTTP response that represents the object.
      *
@@ -18,6 +24,8 @@ class VerifyEmailResponse implements VerifyEmailResponseContract
      */
     public function toResponse($request)
     {
-        return new JsonResponse(['user' => new UserResource(Auth::user())]);
+        return response()->json([
+            'user' => $this->userResource->make($request->user()),
+        ]);
     }
 }

--- a/backend/app/Providers/ApiResourceServiceProvider.php
+++ b/backend/app/Providers/ApiResourceServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Providers;
+
+use App\Http\Resources\ApiResource;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Http\Resources\MissingValue;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * @see https://laravel.com/docs/container#binding
+ */
+class ApiResourceServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        // Resolve even extended classes
+        $this->app->beforeResolving(ApiResource::class, function (
+            string $class,
+            array $parameters,
+        ): void {
+            // For `singleton` instead of `singletonIf`,
+            // resolving multiple times at the same place can lead to infinite loops.
+            $this->app->singletonIf(
+                $class,
+                fn(Application $app): ApiResource => new $class(
+                    // Accept param. e.g. app(UserResource::class, ['resource' => $user]);
+                    $parameters['resource'] ?? $app->make(MissingValue::class),
+                ),
+            );
+        });
+    }
+}

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -171,6 +171,7 @@ return [
         /*
          * Application Service Providers...
          */
+        App\Providers\ApiResourceServiceProvider::class,
         App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
         App\Providers\FortifyServiceProvider::class,


### PR DESCRIPTION
 ## Summary

In order to create API resource instance with DI, the class bindings are required maybe in `ServiceProvider`.
By creating a base `ApiResource` class and bind it with `beforeResolving()`, each binding is unnecessary.
