### PR TITLE
Update deprecated `${}` syntax

### DIFF
--- a/backend/tests/Feature/TaskBoardTest.php
+++ b/backend/tests/Feature/TaskBoardTest.php
@@ -31,13 +31,13 @@ class TaskBoardTest extends TestCase
 
         // index
         $otherUserId = $this->otherUser->id;
-        $url = $this->routePrefix . "/users/${otherUserId}/task-boards";
+        $url = $this->routePrefix . "/users/{$otherUserId}/task-boards";
         $response = $this->getJson($url);
 
         $response->assertUnauthorized();
 
         // create
-        $url = $this->routePrefix . "/users/${otherUserId}/task-boards";
+        $url = $this->routePrefix . "/users/{$otherUserId}/task-boards";
         $response = $this->postJson($url, ['title' => 'testTitle']);
 
         $response->assertUnauthorized();
@@ -45,21 +45,21 @@ class TaskBoardTest extends TestCase
         $boardId = $this->guestUser->taskBoards()->first()->id;
         // show
         $url =
-            $this->routePrefix . "/users/${otherUserId}/task-boards/${boardId}";
+            $this->routePrefix . "/users/{$otherUserId}/task-boards/{$boardId}";
         $response = $this->getJson($url);
 
         $response->assertUnauthorized();
 
         // update
         $url =
-            $this->routePrefix . "/users/${otherUserId}/task-boards/${boardId}";
+            $this->routePrefix . "/users/{$otherUserId}/task-boards/{$boardId}";
         $response = $this->patchJson($url, ['title' => 'testTitle']);
 
         $response->assertUnauthorized();
 
         // delete
         $url =
-            $this->routePrefix . "/users/${otherUserId}/task-boards/${boardId}";
+            $this->routePrefix . "/users/{$otherUserId}/task-boards/{$boardId}";
         $response = $this->deleteJson($url);
 
         $response->assertUnauthorized();
@@ -75,7 +75,7 @@ class TaskBoardTest extends TestCase
         $otherUserId = $this->otherUser->id;
 
         $urlWithOtherUser =
-            $this->routePrefix . "/users/${otherUserId}/task-boards";
+            $this->routePrefix . "/users/{$otherUserId}/task-boards";
 
         // index
         $this->getJson($urlWithOtherUser)->assertForbidden();
@@ -102,11 +102,11 @@ class TaskBoardTest extends TestCase
 
         $urlWithOtherUser =
             $this->routePrefix .
-            "/users/${otherUserId}/task-boards/${authUserboardId}";
+            "/users/{$otherUserId}/task-boards/{$authUserboardId}";
 
         $urlWithOtherBoard =
             $this->routePrefix .
-            "/users/${authUserId}/task-boards/${otherBoardId}";
+            "/users/{$authUserId}/task-boards/{$otherBoardId}";
 
         // show
         $this->getJson($urlWithOtherUser)->assertNotFound();
@@ -126,7 +126,7 @@ class TaskBoardTest extends TestCase
         $this->login($this->guestUser);
 
         $userId = $this->guestUser->id;
-        $url = $this->routePrefix . "/users/${userId}/task-boards";
+        $url = $this->routePrefix . "/users/{$userId}/task-boards";
         $response = $this->getJson($url);
 
         $response->assertJson(
@@ -142,7 +142,7 @@ class TaskBoardTest extends TestCase
         $this->login($this->guestUser);
 
         $userId = $this->guestUser->id;
-        $url = $this->routePrefix . "/users/${userId}/task-boards";
+        $url = $this->routePrefix . "/users/{$userId}/task-boards";
 
         $emptyRequest = [];
         $response = $this->postJson($url, $emptyRequest);
@@ -185,7 +185,7 @@ class TaskBoardTest extends TestCase
 
         $userId = $this->guestUser->id;
         $boardId = $this->guestUser->taskBoards()->first()->id;
-        $url = $this->routePrefix . "/users/${userId}/task-boards/${boardId}";
+        $url = $this->routePrefix . "/users/{$userId}/task-boards/{$boardId}";
 
         $emptyRequest = [];
         $response = $this->patchJson($url, $emptyRequest);
@@ -266,7 +266,7 @@ class TaskBoardTest extends TestCase
 
         $userId = $this->guestUser->id;
         $boardId = (string) Str::uuid();
-        $url = $this->routePrefix . "/users/${userId}/task-boards/${boardId}";
+        $url = $this->routePrefix . "/users/{$userId}/task-boards/{$boardId}";
 
         $successfulRequest = ['title' => str_repeat('!', 20)];
         $response = $this->patchJson($url, $successfulRequest);
@@ -279,7 +279,7 @@ class TaskBoardTest extends TestCase
 
         $userId = $this->guestUser->id;
         $boardId = $this->guestUser->taskBoards()->first()->id;
-        $url = $this->routePrefix . "/users/${userId}/task-boards/${boardId}";
+        $url = $this->routePrefix . "/users/{$userId}/task-boards/{$boardId}";
 
         $response = $this->deleteJson($url);
         $response->assertOk();

--- a/backend/tests/Feature/TaskCardTest.php
+++ b/backend/tests/Feature/TaskCardTest.php
@@ -45,13 +45,13 @@ class TaskCardTest extends TestCase
         $cardId = $this->taskCard->id;
 
         // create
-        $url = $this->routePrefix . "/task-lists/${listId}/task-cards";
+        $url = $this->routePrefix . "/task-lists/{$listId}/task-cards";
         $response = $this->postJson($url, ['title' => 'testTitle']);
         $response->assertUnauthorized();
 
         // update
         $url =
-            $this->routePrefix . "/task-lists/${listId}/task-cards/${cardId}";
+            $this->routePrefix . "/task-lists/{$listId}/task-cards/{$cardId}";
         $response = $this->patchJson($url, ['title' => 'testTitle']);
         $response->assertUnauthorized();
 
@@ -75,7 +75,7 @@ class TaskCardTest extends TestCase
         $otherListId = $otherList->id;
 
         $urlWithOtherList =
-            $this->routePrefix . "/task-lists/${otherListId}/task-cards";
+            $this->routePrefix . "/task-lists/{$otherListId}/task-cards";
 
         // create
         $this->postJson($urlWithOtherList)->assertForbidden();
@@ -105,11 +105,11 @@ class TaskCardTest extends TestCase
 
         $urlWithOtherList =
             $this->routePrefix .
-            "/task-lists/${otherListId}/task-cards/${authUserCardId}";
+            "/task-lists/{$otherListId}/task-cards/{$authUserCardId}";
 
         $urlWithOtherCard =
             $this->routePrefix .
-            "/task-lists/${authUserListId}/task-cards/${otherCardId}";
+            "/task-lists/{$authUserListId}/task-cards/{$otherCardId}";
 
         // update
         $this->patchJson($urlWithOtherList)->assertNotFound();
@@ -132,7 +132,7 @@ class TaskCardTest extends TestCase
         $listId = (string) Str::uuid();
 
         // create
-        $url = $this->routePrefix . "/task-lists/${listId}/task-cards";
+        $url = $this->routePrefix . "/task-lists/{$listId}/task-cards";
         $response = $this->postJson($url, ['title' => 'testTitle']);
         $response->assertNotFound();
 
@@ -144,7 +144,7 @@ class TaskCardTest extends TestCase
         $listId = $this->taskList->id;
         $cardId = (string) Str::uuid();
         $url =
-            $this->routePrefix . "/task-lists/${listId}/task-cards/${cardId}";
+            $this->routePrefix . "/task-lists/{$listId}/task-cards/{$cardId}";
 
         // update
         $response = $this->patchJson($url, ['title' => 'testTitle']);
@@ -160,7 +160,7 @@ class TaskCardTest extends TestCase
         $this->login($this->guestUser);
 
         $listId = $this->taskList->id;
-        $url = $this->routePrefix . "/task-lists/${listId}/task-cards";
+        $url = $this->routePrefix . "/task-lists/{$listId}/task-cards";
 
         // `title`
         $emptyRequest = [];
@@ -229,7 +229,7 @@ class TaskCardTest extends TestCase
         $listId = $this->taskList->id;
         $cardId = $this->taskCard->id;
         $url =
-            $this->routePrefix . "/task-lists/${listId}/task-cards/${cardId}";
+            $this->routePrefix . "/task-lists/{$listId}/task-cards/{$cardId}";
 
         // `title`
         $emptyRequest = [];
@@ -298,7 +298,7 @@ class TaskCardTest extends TestCase
         $listId = $this->taskList->id;
         $cardId = $this->taskCard->id;
         $url =
-            $this->routePrefix . "/task-lists/${listId}/task-cards/${cardId}";
+            $this->routePrefix . "/task-lists/{$listId}/task-cards/{$cardId}";
 
         $cardBeforeDeleted = TaskCard::find($cardId);
         $this->assertNotNull($cardBeforeDeleted);

--- a/backend/tests/Feature/TaskListTest.php
+++ b/backend/tests/Feature/TaskListTest.php
@@ -44,19 +44,19 @@ class TaskListTest extends TestCase
         $listId = $board->taskLists[0]->id;
 
         // create
-        $url = $this->routePrefix . "/task-boards/${boardId}/task-lists";
+        $url = $this->routePrefix . "/task-boards/{$boardId}/task-lists";
         $response = $this->postJson($url, ['title' => 'testTitle']);
         $response->assertUnauthorized();
 
         // update
         $url =
-            $this->routePrefix . "/task-boards/${boardId}/task-lists/${listId}";
+            $this->routePrefix . "/task-boards/{$boardId}/task-lists/{$listId}";
         $response = $this->patchJson($url, ['title' => 'testTitle']);
         $response->assertUnauthorized();
 
         // destroy
         $url =
-            $this->routePrefix . "/task-boards/${boardId}/task-lists/${listId}";
+            $this->routePrefix . "/task-boards/{$boardId}/task-lists/{$listId}";
         $response = $this->deleteJson($url);
         $response->assertUnauthorized();
     }
@@ -75,7 +75,7 @@ class TaskListTest extends TestCase
         $otherBoardId = $otherBoard->id;
 
         $urlWithOtherBoard =
-            $this->routePrefix . "/task-boards/${otherBoardId}/task-lists";
+            $this->routePrefix . "/task-boards/{$otherBoardId}/task-lists";
 
         // create
         $this->postJson($urlWithOtherBoard)->assertForbidden();
@@ -104,11 +104,11 @@ class TaskListTest extends TestCase
 
         $urlWithOtherBoard =
             $this->routePrefix .
-            "/task-boards/${otherBoardId}/task-lists/${authUserListId}";
+            "/task-boards/{$otherBoardId}/task-lists/{$authUserListId}";
 
         $urlWithOtherList =
             $this->routePrefix .
-            "/task-boards/${authUserBoardId}/task-lists/${otherListId}";
+            "/task-boards/{$authUserBoardId}/task-lists/{$otherListId}";
 
         // update
         $this->patchJson($urlWithOtherBoard)->assertNotFound();
@@ -133,13 +133,13 @@ class TaskListTest extends TestCase
 
         // update
         $url =
-            $this->routePrefix . "/task-boards/${boardId}/task-lists/${listId}";
+            $this->routePrefix . "/task-boards/{$boardId}/task-lists/{$listId}";
         $response = $this->patchJson($url, ['title' => 'testTitle']);
         $response->assertNotFound();
 
         // destroy
         $url =
-            $this->routePrefix . "/task-boards/${boardId}/task-lists/${listId}";
+            $this->routePrefix . "/task-boards/{$boardId}/task-lists/{$listId}";
         $response = $this->deleteJson($url);
         $response->assertNotFound();
 
@@ -153,13 +153,13 @@ class TaskListTest extends TestCase
 
         // update
         $url =
-            $this->routePrefix . "/task-boards/${boardId}/task-lists/${listId}";
+            $this->routePrefix . "/task-boards/{$boardId}/task-lists/{$listId}";
         $response = $this->patchJson($url, ['title' => 'testTitle']);
         $response->assertNotFound();
 
         // destroy
         $url =
-            $this->routePrefix . "/task-boards/${boardId}/task-lists/${listId}";
+            $this->routePrefix . "/task-boards/{$boardId}/task-lists/{$listId}";
         $response = $this->deleteJson($url);
         $response->assertNotFound();
     }
@@ -169,7 +169,7 @@ class TaskListTest extends TestCase
         $this->login($this->guestUser);
 
         $boardId = $this->guestUser->taskBoards[0]->id;
-        $url = $this->routePrefix . "/task-boards/${boardId}/task-lists";
+        $url = $this->routePrefix . "/task-boards/{$boardId}/task-lists";
 
         $emptyRequest = [];
         $response = $this->postJson($url, $emptyRequest);
@@ -214,7 +214,7 @@ class TaskListTest extends TestCase
         $boardId = $board->id;
         $listId = $board->taskLists[0]->id;
         $url =
-            $this->routePrefix . "/task-boards/${boardId}/task-lists/${listId}";
+            $this->routePrefix . "/task-boards/{$boardId}/task-lists/{$listId}";
 
         $emptyRequest = [];
         $response = $this->patchJson($url, $emptyRequest);
@@ -260,7 +260,7 @@ class TaskListTest extends TestCase
         $list = $board->taskLists[0];
         $listId = $list->id;
         $url =
-            $this->routePrefix . "/task-boards/${boardId}/task-lists/${listId}";
+            $this->routePrefix . "/task-boards/{$boardId}/task-lists/{$listId}";
 
         $listBeforeDeleted = TaskList::find($listId);
         $cardsBeforeDeleted = TaskCard::where('task_list_id', $listId)->get();


### PR DESCRIPTION
As of PHP8.2