### PR TITLE
Fix Wrong Docker config

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -15,12 +15,12 @@ Dockerfile
 *.dockerignore
 
 # Composer related
-/composer.phar
-/vendor
+composer.phar
+vendor
 
 # Node related
-/node_modules
-/npm-debug.log
+node_modules
+npm-debug.log
 
 storage/*/*
 logs/*

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,7 +9,7 @@ APP_URL="http://${APP_DOMAIN}:${APP_PORT}"
 # cf. https://docs.docker.com/compose/environment-variables/envvars/#compose_project_name
 # cf. https://code.visualstudio.com/remote/advancedcontainers/set-docker-compose-project-name
 # ※ Variables won't be expanded in DevContainer (e.g. app_${APP_ENV} => app_app_env)
-COMPOSE_PROJECT_NAME="laravel-app_local"
+COMPOSE_PROJECT_NAME="laravel-app_${APP_ENV}"
 DOCKER_CONFIG_DIR=./docker
 CONTAINER_PROJECT_DIR=/var/www/html
 CONTAINER_WORKDIR="${CONTAINER_PROJECT_DIR}/backend"
@@ -18,7 +18,7 @@ PHP_VERSION=8.2
 
 LOG_CHANNEL=stack
 LOG_LEVEL=debug
-LOG_SLACK_WEBHOOK_URL=
+LOG_SLACK_WEBHOOK_URL=null
 
 DB_CONNECTION=mysql
 DB_HOST=mysql

--- a/backend/docker-compose.base.yml
+++ b/backend/docker-compose.base.yml
@@ -59,9 +59,6 @@ services:
       mysql:
         condition: service_healthy
         restart: true
-      redis:
-        condition: service_healthy
-        restart: true
   mysql:
     # cf. https://hub.docker.com/_/mariadb
     image: mariadb:10

--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -6,6 +6,11 @@
 # e.g. docker compose -f docker-compose.base.yml -f docker-compose.dev.yml exec -u root php-fpm bash
 
 services:
+  php-fpm:
+    depends_on:
+      redis:
+        condition: service_healthy
+        restart: true
   mysql:
     volumes:
       - type: bind

--- a/backend/docker-compose.devcontainer.yml
+++ b/backend/docker-compose.devcontainer.yml
@@ -1,3 +1,9 @@
+# If it fails to `Reopen in Container`, see the *container* log for the detailed and ensure:
+# - to set `.env` values for the expected environment
+# - to remove the previous volume that affects the subsequent
+# - local builds works (`docker-compose -f docker-compose.base.yml -f docker-compose.dev.yml`)
+# If Git doen’t works, `Manage Unsafe Repositories` form `Source Control` in sidebar.
+
 services:
   php-fpm:
     volumes:

--- a/backend/docker/app/Dockerfile
+++ b/backend/docker/app/Dockerfile
@@ -96,9 +96,9 @@ COPY --from=node --chown=${USER} /usr/local/lib/node_modules/npm /usr/lib/node_m
 RUN mkdir -p ${HOME}/.vscode-server/extensions \
     && chown -R ${USER} ${HOME}/.vscode-server
 
-# Allow the non-root user to access these files.
+# Allow `USER` to access these files.
 RUN mkdir -p ./vendor ./node_modules \
-    && chown -R ${USER}:${USER} ./
+    && chown -R ${USER}:${USER} ./vendor ./node_modules
 
 USER ${USER}
 
@@ -137,12 +137,16 @@ RUN composer dump-autoload --no-dev --classmap-authoritative
 #==========================================================================
 # For production
 #==========================================================================
-FROM base as production
+FROM build as production
 
 # cf. https://hub.docker.com/_/php - Configuration
 RUN mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini
 
 COPY ./ ./
+
+# Allow `USER` to access these files.
+RUN mkdir -p ./bootstrap/cache \
+    && chown ${USER}:${USER} ./bootstrap/cache
 
 COPY --from=build ${WORKDIR}/vendor/ ./vendor/
 COPY --from=build --chown=${USER} ${WORKDIR}/bootstrap/cache/ ./bootstrap/cache/


### PR DESCRIPTION
## Problem

- The same `COMPOSE_PROJECT_NAME` is used between execution environments
- Redis is only used in development
- `USER` has no permission for `bootstrap/cache` (owned by root)