### PR TITLE
Update `.renovaterc.json` about group

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -39,7 +39,6 @@
       "matchManagers": ["composer"],
       "matchDepTypes": ["require-dev"],
       "matchUpdateTypes": ["major"],
-      "groupName": "composer dev-dependencies",
       "addLabels": ["backend", "composer", "dev"]
     },
     {
@@ -63,7 +62,7 @@
       "matchManagers": ["npm"],
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "npm dependencies (non-major)",
+      "groupName": "backend npm dependencies (non-major)",
       "addLabels": ["backend", "npm"]
     },
     {
@@ -71,7 +70,6 @@
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["major"],
-      "groupName": "npm dev-dependencies",
       "addLabels": ["backend", "npm", "dev"]
     },
     {
@@ -79,7 +77,7 @@
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "npm dev-dependencies (non-major)",
+      "groupName": "backend dev-dependencies (non-major)",
       "addLabels": ["backend", "npm", "dev"]
     },
 
@@ -110,7 +108,7 @@
       "matchManagers": ["npm"],
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "npm dependencies (non-major)",
+      "groupName": "frontend npm dependencies (non-major)",
       "addLabels": ["frontend", "npm"]
     },
     {
@@ -118,7 +116,6 @@
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["major"],
-      "groupName": "npm dev-dependencies",
       "addLabels": ["frontend", "npm", "dev"]
     },
     {
@@ -126,7 +123,7 @@
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "npm dev-dependencies (non-major)",
+      "groupName": "frontend npm dev-dependencies (non-major)",
       "addLabels": ["frontend", "npm", "dev"]
     }
   ]


### PR DESCRIPTION
- Remove `groupName` for major update since it may be hard to upgrade at the same time
- Use different `groupName` between backend and frontend as they become the same PR unintentionally